### PR TITLE
update docs url to permanent location

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This is a Plugin for [Rundeck](https://www.rundeck.com/open-source) 3.0.8 that p
 
 ![Screenshot2](resources/expected_result.PNG)
 
-* For complete information on Rundeck refer to https://rundeck.org/docs/
+* For complete information on Rundeck refer to https://docs.rundeck.com/docs/
 
 
 


### PR DESCRIPTION
We recently completed consolidating the Rundeck websites, and this PR updates the Rundeck docs link to the new location.  The existing link works and is redirected... just offering this to help search engines, etc.
